### PR TITLE
TelemetrySavedObjectsClient: Extend `createPointInTimeFinder` to request all `namespaces` by default

### DIFF
--- a/src/plugins/telemetry_collection_manager/server/telemetry_saved_objects_client.ts
+++ b/src/plugins/telemetry_collection_manager/server/telemetry_saved_objects_client.ts
@@ -7,7 +7,12 @@
  */
 
 import type { SavedObjectsFindOptions, SavedObjectsFindResponse } from 'src/core/server';
-import { SavedObjectsClient } from '../../../core/server';
+import {
+  ISavedObjectsPointInTimeFinder,
+  SavedObjectsClient,
+  SavedObjectsCreatePointInTimeFinderDependencies,
+  SavedObjectsCreatePointInTimeFinderOptions,
+} from '../../../core/server';
 
 /**
  * Extends the SavedObjectsClient to fit the telemetry fetching requirements (i.e.: find objects from all namespaces by default)
@@ -21,5 +26,17 @@ export class TelemetrySavedObjectsClient extends SavedObjectsClient {
     options: SavedObjectsFindOptions
   ): Promise<SavedObjectsFindResponse<T, A>> {
     return super.find({ namespaces: ['*'], ...options });
+  }
+
+  /**
+   * Extends {@link SavedObjectsClient.createPointInTimeFinder} by performing the request to all the Spaces by default
+   * @param findOptions
+   * @param dependencies
+   */
+  createPointInTimeFinder(
+    findOptions: SavedObjectsCreatePointInTimeFinderOptions,
+    dependencies?: SavedObjectsCreatePointInTimeFinderDependencies
+  ): ISavedObjectsPointInTimeFinder {
+    return super.createPointInTimeFinder({ namespaces: ['*'], ...findOptions }, dependencies);
   }
 }


### PR DESCRIPTION
## Summary

Testing #99031 with the TelemetrySavedObjectsClient also providing `namespaces: ['*']` by default.

If we agree that this solves the issue found in https://github.com/elastic/kibana/pull/99031/files#r625048399 I'm happy to close this PR and create these changes on their own against `master`, then we can rebase the original PR 🙂 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
